### PR TITLE
Update classes_to_search to correctly show the expected data structure

### DIFF
--- a/src/Extensions/SearchControllerExtension.php
+++ b/src/Extensions/SearchControllerExtension.php
@@ -51,10 +51,10 @@ class SearchControllerExtension extends Extension
      * @var array
      */
     private static $classes_to_search = [
-        [
-            'class' => 'Page',
+        Page::class => [
+            'class' => Page::class,
             'includeSubclasses' => true,
-        ]
+        ],
     ];
 
     /**


### PR DESCRIPTION
Issue: https://github.com/silverstripe/cwp-search/issues/3

The data structure for this is expected to have the class name as the array key. This updates to ensure that developers will see this when extending it.