### PR TITLE
API Update fulltextsearch API implementations for 3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "cwp/cwp": "^2",
-        "silverstripe/fulltextsearch": "^3"
+        "silverstripe/fulltextsearch": "^3.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/src/CwpSearchEngine.php
+++ b/src/CwpSearchEngine.php
@@ -57,12 +57,12 @@ class CwpSearchEngine
     {
         $query = new SearchQuery();
         $query->classes = $classes;
-        $query->search($keywords);
-        $query->exclude(SiteTree::class . '_ShowInSearch', 0);
+        $query->addSearchTerm($keywords);
+        $query->addExclude(SiteTree::class . '_ShowInSearch', 0);
 
         // Artificially lower the amount of results to prevent too high resource usage.
         // on subsequent canView check loop.
-        $query->limit(100);
+        $query->setLimit(100);
 
         // Allow user code to modify the search query before returning it
         $this->extend('updateSearchQuery', $query);

--- a/src/Solr/CwpSolr.php
+++ b/src/Solr/CwpSolr.php
@@ -26,7 +26,7 @@ class CwpSolr
      * $options - An array consisting of:
      *
      * 'extraspath' - (String) Where to find Solr core configuartion files.
-     *     Defaults to '<BASE_PATH>/mysite/conf/extras'.
+     *     Defaults to '<BASE_PATH>/app/conf/extras'.
      * 'version' - select the Solr configuration to use when in CWP. One of:
      * * 'cwp-4': preferred version, uses secured 4.x service available on CWP
      * * 'local-4': this can be use for development using silverstripe-localsolr package, 4.x branch
@@ -62,8 +62,8 @@ class CwpSolr
         // CAUTION: CWP does not permit usage of customised solrconfig.xml.
         if (isset($options['extraspath']) && file_exists($options['extraspath'])) {
             $solrOptions['extraspath'] = $options['extraspath'];
-        } elseif (file_exists(BASE_PATH . '/mysite/conf/extras')) {
-            $solrOptions['extraspath'] = BASE_PATH . '/mysite/conf/extras';
+        } elseif (file_exists(BASE_PATH . '/app/conf/extras')) {
+            $solrOptions['extraspath'] = BASE_PATH . '/app/conf/extras';
         }
 
         Solr::configure_server($solrOptions);


### PR DESCRIPTION
Some methods we use are deprecated now, and this also updates the optional Solr extras path from mysite to app for SilverStripe 4.2.x (CWP 2.1)