### PR TITLE
Fix undefined index notice

### DIFF
--- a/src/Solr/CwpSolrConfigStore.php
+++ b/src/Solr/CwpSolrConfigStore.php
@@ -35,7 +35,10 @@ class CwpSolrConfigStore implements SolrConfigStore
             $options['host'] . ':' . $options['port'],
             $config['path']
         ]);
-        $this->remote = $config['remotepath'];
+        
+        if (isset($config['remotepath'])) {
+            $this->remote = $config['remotepath'];
+        }
     }
 
     /**


### PR DESCRIPTION
`remotepath` doesn't exist in `options_for_cwp()` and causes Undefined Index notices when deployed