### PR TITLE
API Custom configstore has been moved to fulltextsearch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "cwp/cwp": "^2",
-        "silverstripe/fulltextsearch": "^3.3"
+        "silverstripe/fulltextsearch": "^3@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/src/Solr/CwpSolr.php
+++ b/src/Solr/CwpSolr.php
@@ -83,7 +83,7 @@ class CwpSolr
             'path' => '/v4/',
             'version' => 4,
             'indexstore' => [
-                'mode' => CwpSolrConfigStore::class,
+                'mode' => 'post',
                 'path' => '/v4',
             ],
         ];

--- a/src/Solr/CwpSolrConfigStore.php
+++ b/src/Solr/CwpSolrConfigStore.php
@@ -6,9 +6,7 @@ use SilverStripe\FullTextSearch\Solr\Solr;
 use SilverStripe\FullTextSearch\Solr\Stores\SolrConfigStore;
 
 /**
- * Class CwpSolrConfigStore
- *
- * Uploads configuration to Solr via the PHP proxy CWP uses to filter requests
+ * @deprecated 1.2.0 Use SolrConfigStore_Post in silverstripe/fulltextsearch instead
  */
 class CwpSolrConfigStore implements SolrConfigStore
 {
@@ -35,7 +33,7 @@ class CwpSolrConfigStore implements SolrConfigStore
             $options['host'] . ':' . $options['port'],
             $config['path']
         ]);
-        
+
         if (isset($config['remotepath'])) {
             $this->remote = $config['remotepath'];
         }


### PR DESCRIPTION
As of https://github.com/silverstripe/silverstripe-fulltextsearch/pull/246/files `CwpSolrConfigStore` now exists in the `fulltextsearch` module. This configure solr to use that.