### PR TITLE
getFieldDefinitions is needed to be cast as HTML

### DIFF
--- a/src/CwpSearchIndex.php
+++ b/src/CwpSearchIndex.php
@@ -27,6 +27,11 @@ abstract class CwpSearchIndex extends SolrIndex
         '_text',
         '_spellcheckText',
     ];
+    
+    private static $casting = [
+        'getFieldDefinitions' => 'HTMLText',
+        'FieldDefinitions' => 'HTMLText'
+    ];
 
     /**
      * Default dictionary to use. This will overwrite the 'spellcheck.dictionary' option for searches given,


### PR DESCRIPTION
Otherwise invalid XML is generated during Solr_Configure.