### PR TITLE
Allow environment configuration of indexstore port in local environments

### DIFF
--- a/src/Solr/CwpSolr.php
+++ b/src/Solr/CwpSolr.php
@@ -111,7 +111,14 @@ class CwpSolr
                     : BASE_PATH . '/.solr',
                 'remotepath' => Environment::getEnv('SOLR_REMOTE_PATH')
                     ? Environment::getEnv('SOLR_REMOTE_PATH')
-                    : null
+                    : null,
+                'port' => Environment::getEnv('SOLR_INDEXSTORE_PORT')
+                    ? Environment::getEnv('SOLR_INDEXSTORE_PORT')
+                    : (
+                        Environment::getEnv('SOLR_PORT')
+                            ? Environment::getEnv('SOLR_PORT')
+                            : 8983
+                    )
             ]
         ];
     }


### PR DESCRIPTION
The indexstore port may be different to the solr port where the server is running and currently there's no way to configure this from the environment level.