### PR TITLE
FIX Solr communication error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,14 @@
         "php": "^7.3 || ^8.0",
         "silverstripe/framework": "^4.10",
         "cwp/cwp": "^2",
-        "silverstripe/fulltextsearch": "^3"
+        "silverstripe/fulltextsearch": "^3.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3"
+    },
+    "conflict": {
+        "silverstripe/auditor": "<2.2.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/37

https://github.com/silverstripe/cwp-search/runs/7350149872?check_suite_focus=true#step:10:822
`PHP Fatal error:  Uncaught Apache_Solr_HttpTransportException: '0' Status: Communication Error in /home/runner/work/cwp-search/cwp-search/vendor/ptcinc/solr-php-client/Apache/Solr/Service.php:364`

Only happens on --prefer-lowest build

I'm not sure exactly what in fulltextsearch ^3.4 is required - it's something in [here](https://github.com/silverstripe/silverstripe-fulltextsearch/compare/3.3.0...3.4.0) - ^3.3 will cause the build to fail

Auditor conflict is to fix a deprecated parameter order issue