### PR TITLE
Search link is using relative link

### DIFF
--- a/src/CwpSearchResult.php
+++ b/src/CwpSearchResult.php
@@ -202,7 +202,7 @@ class CwpSearchResult extends ViewableData
             return null;
         }
         $link = Director::absoluteBaseURL();
-        $link .= '/search/SearchForm?Search='.rawurlencode($terms ?? '');
+        $link .= 'search/SearchForm?Search='.rawurlencode($terms ?? '');
         if ($format) {
             $link .= '&format='.rawurlencode($format ?? '');
         }

--- a/src/CwpSearchResult.php
+++ b/src/CwpSearchResult.php
@@ -200,7 +200,7 @@ class CwpSearchResult extends ViewableData
         if (!$terms) {
             return null;
         }
-        $link = 'search/SearchForm?Search='.rawurlencode($terms ?? '');
+        $link = '/search/SearchForm?Search='.rawurlencode($terms ?? '');
         if ($format) {
             $link .= '&format='.rawurlencode($format ?? '');
         }

--- a/src/CwpSearchResult.php
+++ b/src/CwpSearchResult.php
@@ -2,6 +2,7 @@
 
 namespace CWP\Search;
 
+use SilverStripe\Control\Director;
 use SilverStripe\FullTextSearch\Search\Services\SearchableService;
 use SilverStripe\ORM\PaginatedList;
 use SilverStripe\View\ArrayData;
@@ -200,7 +201,8 @@ class CwpSearchResult extends ViewableData
         if (!$terms) {
             return null;
         }
-        $link = '/search/SearchForm?Search='.rawurlencode($terms ?? '');
+        $link = Director::absoluteBaseURL();
+        $link .= '/search/SearchForm?Search='.rawurlencode($terms ?? '');
         if ($format) {
             $link .= '&format='.rawurlencode($format ?? '');
         }

--- a/src/Extensions/SearchControllerExtension.php
+++ b/src/Extensions/SearchControllerExtension.php
@@ -72,7 +72,7 @@ class SearchControllerExtension extends Extension
         );
 
         $form = SearchForm::create($this->owner, SearchForm::class, $fields, $actions);
-        $form->setFormAction('search/SearchForm');
+        $form->setFormAction('/search/SearchForm');
 
         return $form;
     }

--- a/src/Extensions/SearchControllerExtension.php
+++ b/src/Extensions/SearchControllerExtension.php
@@ -5,6 +5,7 @@ namespace CWP\Search\Extensions;
 use CWP\Search\CwpSearchEngine;
 use Page;
 use SilverStripe\CMS\Search\SearchForm;
+use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Extension;
@@ -72,7 +73,7 @@ class SearchControllerExtension extends Extension
         );
 
         $form = SearchForm::create($this->owner, SearchForm::class, $fields, $actions);
-        $form->setFormAction('/search/SearchForm');
+        $form->setFormAction(Director::absoluteBaseURL().'search/SearchForm');
 
         return $form;
     }


### PR DESCRIPTION
When a user search on a page that is not the home page, it appends the search link behind the current url. e.g. `mysite.test/my-page/search/SearchForm?Search=test` instead of `mysite.test/search/SearchForm?Search=test`

## Parent issue
- #49