### PR TITLE
FIX Add slash before search action in Search form url

### DIFF
--- a/src/Extensions/SearchControllerExtension.php
+++ b/src/Extensions/SearchControllerExtension.php
@@ -73,7 +73,7 @@ class SearchControllerExtension extends Extension
         );
 
         $form = SearchForm::create($this->owner, SearchForm::class, $fields, $actions);
-        $form->setFormAction(Director::absoluteBaseURL().'search/SearchForm');
+        $form->setFormAction(Director::absoluteURL('search/SearchForm'));
 
         return $form;
     }


### PR DESCRIPTION
### Description
Method `Director::absoluteBaseURL()` was replaced with `Director::absoluteURL()` to add slash before `search` action.

### Parent issue
- https://github.com/silverstripe/cwp-search/issues/54