### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^7.3 || ^8.0",
-        "silverstripe/framework": "4.13.x-dev",
-        "cwp/cwp": "2.11.x-dev",
-        "silverstripe/fulltextsearch": "3.12.x-dev"
+        "silverstripe/framework": "^4.10",
+        "cwp/cwp": "^2",
+        "silverstripe/fulltextsearch": "^3.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

## Issue
- https://github.com/silverstripe/.github/issues/33